### PR TITLE
Add a custom breadcrumb builder for the party dashboard.

### DIFF
--- a/contacts.services.yml
+++ b/contacts.services.yml
@@ -1,4 +1,8 @@
 services:
+  contacts.breadcrumb_builder:
+    class: Drupal\contacts\BreadcrumbBuilder
+    tags:
+      - { name: breadcrumb_builder, priority: 10 }
   contacts.theme.negotiator:
     class: Drupal\contacts\Theme\DashboardNegotiator
     tags:

--- a/src/BreadcrumbBuilder.php
+++ b/src/BreadcrumbBuilder.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\contacts;
+
+use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Build the breadcrumbs on the party dashboard.
+ */
+class BreadcrumbBuilder implements BreadcrumbBuilderInterface {
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(RouteMatchInterface $route_match) {
+    return in_array(
+      $route_match->getRouteName(),
+      [
+        'page_manager.page_view_contacts_dashboard_contact',
+        'page_manager.page_view_contacts_dashboard',
+      ]
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(RouteMatchInterface $route_match) {
+    $breadcrumb = new Breadcrumb();
+    $links = [];
+
+    $links[] = Link::createFromRoute($this->t('Contacts'), 'page_manager.page_view_contacts_dashboard');
+
+    if ($route_match->getRouteName() == 'page_manager.page_view_contacts_dashboard_contact') {
+      $user = $route_match->getParameter('user');
+      $links[] = Link::createFromRoute(
+        $user->label(),
+        'page_manager.page_view_contacts_dashboard_contact',
+        [
+          'user' => $user->id(),
+        ]
+      );
+    }
+
+    return $breadcrumb->setLinks($links);
+  }
+}


### PR DESCRIPTION
Add a custom breadcrumb builder so that breadcrumbs don't include the extra page at the end. This means that the breadcrumbs on the Dashboard are always Contacts >> Contact