### PR TITLE
Null check in contacts_views_post_render

### DIFF
--- a/contacts.module
+++ b/contacts.module
@@ -534,7 +534,7 @@ function contacts_preprocess_views_view_unformatted(&$variables) {
  * Implements hook_views_post_render().
  */
 function contacts_views_post_render(ViewExecutable $view, &$output, CachePluginBase $cache) {
-  if (isset($output['#view']) && $output['#view']->id() == 'contacts_dashboard_indexed') {
+  if (array_key_exists('#view', $output) && $output['#view']->id() == 'contacts_dashboard_indexed') {
     $output['#attached']['library'][] = 'contacts/listings';
   }
 }

--- a/contacts.module
+++ b/contacts.module
@@ -534,7 +534,7 @@ function contacts_preprocess_views_view_unformatted(&$variables) {
  * Implements hook_views_post_render().
  */
 function contacts_views_post_render(ViewExecutable $view, &$output, CachePluginBase $cache) {
-  if ($output['#view']->id() == 'contacts_dashboard_indexed') {
+  if (isset($output['#view']) && $output['#view']->id() == 'contacts_dashboard_indexed') {
     $output['#attached']['library'][] = 'contacts/listings';
   }
 }


### PR DESCRIPTION
contacts_views_post_render should check if $output['#view'] is set as this may not be present for certain view displays (eg when using views_data_export). @yanniboi please could this be merged into proto/nw-demo?